### PR TITLE
feat: improve sanity client interop

### DIFF
--- a/src/encoders/sanity/__test__/decode.test.ts
+++ b/src/encoders/sanity/__test__/decode.test.ts
@@ -2,7 +2,8 @@ import {expect, test} from 'vitest'
 
 import {at, patch} from '../../../mutations/creators'
 import {insert, set, unset} from '../../../mutations/operations/creators'
-import {decodeAll, type SanityMutation} from '../decode'
+import {decodeAll} from '../decode'
+import {type SanityMutation} from '../types'
 
 test('decode()', () => {
   const encoded: SanityMutation[] = [

--- a/src/encoders/sanity/encode.ts
+++ b/src/encoders/sanity/encode.ts
@@ -1,10 +1,12 @@
+import {type PatchMutationOperation} from '@sanity/client'
+
 import {
   type Mutation,
   type NodePatch,
   type Transaction,
 } from '../../mutations/types'
 import {stringify as stringifyPath} from '../../path/parser/stringify'
-import {type SanityMutation, type SanityPatchMutation} from './decode'
+import {type SanityMutation} from './types'
 
 export function encode(mutation: Mutation): SanityMutation[] | SanityMutation {
   return encodeMutation(mutation)
@@ -44,7 +46,7 @@ export function encodeMutation(
             ...(ifRevisionID && {ifRevisionID}),
             ...patchToSanity(patch),
           },
-        } as SanityPatchMutation
+        } as {id: string; patch: PatchMutationOperation}
       })
     }
   }

--- a/src/encoders/sanity/index.ts
+++ b/src/encoders/sanity/index.ts
@@ -1,2 +1,3 @@
 export * from './decode'
 export * from './encode'
+export * from './types'

--- a/src/encoders/sanity/types.ts
+++ b/src/encoders/sanity/types.ts
@@ -1,0 +1,86 @@
+import {
+  type Mutation as SanityMutation,
+  type PatchMutationOperation,
+  type PatchOperations,
+} from '@sanity/client'
+
+import {
+  type IdentifiedSanityDocument,
+  type SanityDocumentBase,
+} from '../../mutations/types'
+
+export type {PatchMutationOperation, SanityMutation}
+
+export type SanityDiffMatchPatch = {
+  id: string
+  diffMatchPatch: {[path: string]: string}
+}
+
+export type SanitySetPatch = {
+  id: string
+  set: {[path: string]: any}
+}
+
+export type InsertBefore = {
+  before: string
+  items: any[]
+}
+
+export type InsertAfter = {
+  after: string
+  items: any[]
+}
+
+export type InsertReplace = {
+  replace: string
+  items: any[]
+}
+
+export type Insert = InsertBefore | InsertAfter | InsertReplace
+
+export type SanityInsertPatch = {
+  id: string
+  insert: Insert
+}
+
+export type SanityUnsetPatch = {
+  id: string
+  unset: string[]
+}
+
+export type SanityIncPatch = {
+  id: string
+  inc: {[path: string]: number}
+}
+
+export type SanityDecPatch = {
+  id: string
+  dec: {[path: string]: number}
+}
+
+export type SanitySetIfMissingPatch = {
+  id: string
+  setIfMissing: {[path: string]: any}
+}
+
+export type SanityPatch = PatchOperations & {id: string}
+
+export type SanityCreateIfNotExistsMutation<
+  Doc extends IdentifiedSanityDocument = IdentifiedSanityDocument,
+> = {
+  createIfNotExists: Doc
+}
+
+export type SanityCreateOrReplaceMutation<
+  Doc extends IdentifiedSanityDocument = IdentifiedSanityDocument,
+> = {
+  createOrReplace: Doc
+}
+
+export type SanityCreateMutation<Doc extends SanityDocumentBase> = {
+  create: Doc
+}
+
+export type SanityDeleteMutation = {
+  delete: {id: string}
+}

--- a/src/mutations/types.ts
+++ b/src/mutations/types.ts
@@ -16,6 +16,10 @@ export interface SanityDocumentBase {
   _rev?: string
 }
 
+export interface IdentifiedSanityDocument extends SanityDocumentBase {
+  _id: string
+}
+
 export type CreateMutation<Doc extends Optional<SanityDocumentBase, '_id'>> = {
   type: 'create'
   document: Doc

--- a/src/store/sanityMutationTypes.ts
+++ b/src/store/sanityMutationTypes.ts
@@ -9,8 +9,6 @@ export type {
   SanityIncPatch,
   SanityInsertPatch,
   SanityMutation,
-  SanityPatch,
-  SanityPatchMutation,
   SanitySetIfMissingPatch,
   SanitySetPatch,
   SanityUnsetPatch,


### PR DESCRIPTION
### Description
Fixes interop with `@sanity/client` types by importing relevant types from `@sanity/client` instead of relying on local types that structurally match (ish). Should unblock https://github.com/sanity-io/sanity/pull/10468

### What to review
These modifications are only on the type level, and should not affect runtime behavior

### Testing

Existing tests should be enough