### PR TITLE
fix: stable store multiple submits

### DIFF
--- a/src/store/__test__/submitOnce.test.ts
+++ b/src/store/__test__/submitOnce.test.ts
@@ -1,0 +1,109 @@
+import {NEVER, of} from 'rxjs'
+import {describe, expect, test, vi} from 'vitest'
+
+import {createOptimisticStore} from '../optimistic/createOptimisticStore'
+import {collectNotifications, sleep} from './helpers'
+
+describe('submit callback deduplication', () => {
+  test('submit callback is called once per submit, regardless of number of listeners', async () => {
+    const submitCallback = vi.fn().mockReturnValue(of({}))
+
+    const store = createOptimisticStore({
+      listen: id => of({type: 'sync', id, document: {_id: id, _type: 'test'}}),
+      submit: submitCallback,
+    })
+
+    // Subscribe to multiple documents
+    const listener1 = collectNotifications(store.listen('doc1'))
+    const listener2 = collectNotifications(store.listen('doc2'))
+    const listener3 = collectNotifications(store.listen('doc3'))
+
+    // Wait for initial sync
+    await sleep(10)
+
+    // Add some mutations
+    store.mutate([{type: 'patch', id: 'doc1', patches: []}])
+    store.mutate([{type: 'patch', id: 'doc2', patches: []}])
+
+    // Submit once
+    store.submit()
+
+    // Wait for async operations
+    await sleep(50)
+
+    // Submit callback should be called exactly once (with one transaction)
+    expect(submitCallback).toHaveBeenCalledTimes(1)
+
+    // Cleanup
+    listener1.unsubscribe()
+    listener2.unsubscribe()
+    listener3.unsubscribe()
+  })
+
+  test('submit callback is called once even with many listeners', async () => {
+    const submitCallback = vi.fn().mockReturnValue(of({}))
+
+    const store = createOptimisticStore({
+      listen: id => of({type: 'sync', id, document: {_id: id, _type: 'test'}}),
+      submit: submitCallback,
+    })
+
+    // Subscribe to 10 documents
+    const listeners = Array.from({length: 10}, (_, i) =>
+      collectNotifications(store.listen(`doc${i}`)),
+    )
+
+    // Wait for initial sync
+    await sleep(10)
+
+    // Add a mutation
+    store.mutate([{type: 'patch', id: 'doc0', patches: []}])
+
+    // Submit once
+    store.submit()
+
+    // Wait for async operations
+    await sleep(50)
+
+    // Submit callback should be called exactly once
+    expect(submitCallback).toHaveBeenCalledTimes(1)
+
+    // Cleanup
+    listeners.forEach(l => l.unsubscribe())
+  })
+
+  test('multiple submits call submit callback once per submit', async () => {
+    const submitCallback = vi.fn().mockReturnValue(of({}))
+
+    const store = createOptimisticStore({
+      listen: id => of({type: 'sync', id, document: {_id: id, _type: 'test'}}),
+      submit: submitCallback,
+    })
+
+    // Subscribe to multiple documents
+    const listener1 = collectNotifications(store.listen('doc1'))
+    const listener2 = collectNotifications(store.listen('doc2'))
+
+    // Wait for initial sync
+    await sleep(10)
+
+    // First batch of mutations
+    store.mutate([{type: 'patch', id: 'doc1', patches: []}])
+    store.submit()
+
+    await sleep(10)
+
+    // Second batch of mutations
+    store.mutate([{type: 'patch', id: 'doc2', patches: []}])
+    store.submit()
+
+    await sleep(50)
+
+    // Submit callback should be called exactly twice (once per submit)
+    expect(submitCallback).toHaveBeenCalledTimes(2)
+
+    // Cleanup
+    listener1.unsubscribe()
+    listener2.unsubscribe()
+  })
+})

--- a/src/store/optimistic/createOptimisticStore.ts
+++ b/src/store/optimistic/createOptimisticStore.ts
@@ -256,21 +256,17 @@ export function createOptimisticStoreInternal(
         }),
       )
     }),
-    share(),
-  )
-
-  // Execute submit side-effect globally (once per submit), not per-listener.
-  // We subscribe eagerly so submissions happen regardless of listener state.
-  // The subscription is kept alive by the store itself.
-  submitRequests
-    .pipe(
-      concatMap(submitRequest =>
+    concatMap(submitRequest =>
+      merge(
+        of(submitRequest),
         from(submitRequest.transaction).pipe(
           concatMap(transaction => submitTransactions(transaction)),
+          mergeMap(() => EMPTY),
         ),
       ),
-    )
-    .subscribe()
+    ),
+    share(),
+  )
 
   return {
     listen(id: string): Observable<SanityDocumentBase | undefined> {

--- a/src/store/optimistic/createOptimisticStore.ts
+++ b/src/store/optimistic/createOptimisticStore.ts
@@ -242,6 +242,7 @@ export function createOptimisticStoreInternal(
       return current
     }, []),
   )
+  // Create the submit requests observable with share() to multicast to listeners
   const submitRequests = onSubmitLocal.pipe(
     withLatestFrom(pendingMutations),
     mergeMap(([, mutationGroups]) => {
@@ -257,6 +258,19 @@ export function createOptimisticStoreInternal(
     }),
     share(),
   )
+
+  // Execute submit side-effect globally (once per submit), not per-listener.
+  // We subscribe eagerly so submissions happen regardless of listener state.
+  // The subscription is kept alive by the store itself.
+  submitRequests
+    .pipe(
+      concatMap(submitRequest =>
+        from(submitRequest.transaction).pipe(
+          concatMap(transaction => submitTransactions(transaction)),
+        ),
+      ),
+    )
+    .subscribe()
 
   return {
     listen(id: string): Observable<SanityDocumentBase | undefined> {
@@ -281,15 +295,6 @@ export function createOptimisticStoreInternal(
 
       return merge(
         remoteSync,
-        // subscribing for the side effect
-        submitRequests.pipe(
-          concatMap(submitRequest =>
-            from(submitRequest.transaction).pipe(
-              concatMap(transaction => submitTransactions(transaction)),
-              mergeMap(() => EMPTY),
-            ),
-          ),
-        ),
         submitRequests,
         localMutations.pipe(
           map(m => ({type: 'localMutation' as const, mutations: m})),


### PR DESCRIPTION
### Description

Prevent submit callback from being called multiple times per submit.

When calling `store.submit()` once, the submit callback provided to `createOptimisticStore()` was being invoked multiple times (once per active document listener) with the same transaction. This caused:

- Duplicate API requests to the backend
- 1 success + N-1 `409 Conflict` errors from the API
- Wasted bandwidth and potential race conditions

### Root Cause

The submit side-effect was placed **inside** each document listener's RxJS observable pipeline:

```
return merge(
  remoteSync,
  // Each listener had its own subscription to this side-effect
  submitRequests.pipe(
    concatMap(submitRequest =>
      from(submitRequest.transaction).pipe(
        concatMap(transaction => submitTransactions(transaction)), // Called per listener!
      ),
    ),
  ),
  // ...
)
```


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
