### PR TITLE
fix: clear pending commits

### DIFF
--- a/src/store/__test__/submitOnce.test.ts
+++ b/src/store/__test__/submitOnce.test.ts
@@ -4,6 +4,67 @@ import {describe, expect, test, vi} from 'vitest'
 import {createOptimisticStore} from '../optimistic/createOptimisticStore'
 import {collectNotifications, sleep} from './helpers'
 
+describe('submit clears pending mutations', () => {
+  test('mutations are cleared after submit and not re-sent on subsequent submits', async () => {
+    const submittedMutations: unknown[] = []
+    const submitCallback = vi.fn().mockImplementation(transaction => {
+      submittedMutations.push(transaction)
+      return of({})
+    })
+
+    const store = createOptimisticStore({
+      listen: id => of({type: 'sync', id, document: {_id: id, _type: 'test'}}),
+      submit: submitCallback,
+    })
+
+    // Subscribe to a document
+    const listener = collectNotifications(store.listen('doc1'))
+    await sleep(10)
+
+    // First mutation: set field1
+    store.mutate([
+      {
+        type: 'patch',
+        id: 'doc1',
+        patches: [{path: ['field1'], op: {type: 'set', value: 'a'}}],
+      },
+    ])
+    store.submit()
+    await sleep(50)
+
+    // First submit should send the first mutation
+    expect(submitCallback).toHaveBeenCalledTimes(1)
+    const firstSubmit = submittedMutations[0] as {mutations: unknown[]}
+    expect(firstSubmit.mutations.length).toBeGreaterThan(0)
+
+    // Second mutation: set field2
+    store.mutate([
+      {
+        type: 'patch',
+        id: 'doc1',
+        patches: [{path: ['field2'], op: {type: 'set', value: 'b'}}],
+      },
+    ])
+    store.submit()
+    await sleep(50)
+
+    // Second submit should only send the second mutation, not both
+    expect(submitCallback).toHaveBeenCalledTimes(2)
+    const secondSubmit = submittedMutations[1] as {mutations: unknown[]}
+    // The second submit should NOT contain the first mutation (field1)
+    // It should only contain the second mutation (field2)
+    expect(secondSubmit.mutations.length).toBeGreaterThan(0)
+    // Verify the patches don't include the first mutation
+    const secondPatches = secondSubmit.mutations.flatMap((m: any) => m.patch || [])
+    const hasField1 = secondPatches.some((p: any) =>
+      JSON.stringify(p).includes('field1'),
+    )
+    expect(hasField1).toBe(false)
+
+    listener.unsubscribe()
+  })
+})
+
 describe('submit callback deduplication', () => {
   test('submit callback is called once per submit, regardless of number of listeners', async () => {
     const submitCallback = vi.fn().mockReturnValue(of({}))

--- a/src/store/optimistic/createOptimisticStore.ts
+++ b/src/store/optimistic/createOptimisticStore.ts
@@ -167,6 +167,9 @@ export function createOptimisticStoreInternal(
   // this causes pending, unsubmitted mutations to be replaced with rebased mutations
   const rebasedMutations = new Subject<readonly MutationGroup[]>()
 
+  // Signals that pending mutations should be cleared after they've been captured for submit
+  const clearPendingMutations = new Subject<void>()
+
   function listenDocumentUpdates<Doc extends SanityDocumentBase>(
     documentId: string,
   ) {
@@ -230,6 +233,10 @@ export function createOptimisticStoreInternal(
       // if pending mutations are rebased
       map(mutations => ({type: 'rebase' as const, mutations})),
     ),
+    clearPendingMutations.pipe(
+      // clear pending mutations after they've been captured for submit
+      map(() => ({type: 'clear' as const})),
+    ),
   ).pipe(
     scan((current: readonly MutationGroup[], action) => {
       if (action.type === 'rebase') {
@@ -239,6 +246,9 @@ export function createOptimisticStoreInternal(
       if (action.type === 'add') {
         return current.concat(action.mutations)
       }
+      if (action.type === 'clear') {
+        return []
+      }
       return current
     }, []),
   )
@@ -246,6 +256,9 @@ export function createOptimisticStoreInternal(
   const submitRequests = onSubmitLocal.pipe(
     withLatestFrom(pendingMutations),
     mergeMap(([, mutationGroups]) => {
+      // Clear pending mutations now that we've captured them for this submit
+      clearPendingMutations.next()
+
       const transactions = toTransactions(
         squashDMPStrings(edge, squashMutationGroups(mutationGroups)),
       )


### PR DESCRIPTION
### Description

The pendingMutations observable was never cleared after submit(), causing mutations to accumulate and be re-sent on subsequent submits.

Added a clearPendingMutations Subject that signals to clear the queue after mutations have been captured for submission.

Also added test.

BTW: this build on my [previous PR](https://github.com/sanity-io/mutate/pull/88).


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
