### PR TITLE
fix: optimistic store listen events

### DIFF
--- a/src/store/__test__/collaborative.test.ts
+++ b/src/store/__test__/collaborative.test.ts
@@ -45,8 +45,8 @@ test('concurrent edits from two clients on different fields are merged', async (
     .map(n => (n as any).value)
     .at(-1)
 
-  expect(aLast).toEqual({_id: id, _type: 'demo', title: 'A1', count: 1})
-  expect(bLast).toEqual({_id: id, _type: 'demo', title: 'A1', count: 1})
+  expect(aLast).toMatchObject({_id: id, _type: 'demo', title: 'A1', count: 1})
+  expect(bLast).toMatchObject({_id: id, _type: 'demo', title: 'A1', count: 1})
 
   aObs.unsubscribe()
   bObs.unsubscribe()

--- a/src/store/documentMap/applyMutations.ts
+++ b/src/store/documentMap/applyMutations.ts
@@ -60,6 +60,7 @@ export function applyMutations<T extends SanityDocumentBase>(
       documentMap.set(documentId, res.after)
 
       updatedDocs[documentId]!.after = res.after
+      updatedDocs[documentId]!.muts.push(mutation)
     }
   }
 

--- a/src/store/optimistic/createOptimisticStore.ts
+++ b/src/store/optimistic/createOptimisticStore.ts
@@ -1,6 +1,7 @@
 import {
   concat,
   concatMap,
+  EMPTY,
   filter,
   from,
   map,
@@ -162,8 +163,12 @@ export function createOptimisticStore(
         const remoteEvents$ = backend.listen(id).pipe(share())
 
         const subscription = merge(
-          remoteEvents$.pipe(map(event => ({source: 'remote' as const, event}))),
-          localMutations$.pipe(map(group => ({source: 'local' as const, group}))),
+          remoteEvents$.pipe(
+            map(event => ({source: 'remote' as const, event})),
+          ),
+          localMutations$.pipe(
+            map(group => ({source: 'local' as const, group})),
+          ),
         ).subscribe({
           next: action => {
             if (action.source === 'remote') {

--- a/src/store/optimistic/createOptimisticStore.ts
+++ b/src/store/optimistic/createOptimisticStore.ts
@@ -1,13 +1,12 @@
 import {
   concat,
   concatMap,
-  EMPTY,
   filter,
   from,
   map,
   merge,
   mergeMap,
-  type Observable,
+  Observable,
   of,
   share,
   startWith,
@@ -101,7 +100,184 @@ export function createOptimisticStore(
     listenEvents(
       id: string,
     ): Observable<RemoteDocumentEvent | OptimisticDocumentEvent> {
-      return EMPTY
+      return new Observable(subscriber => {
+        // State that tracks both remote and local document versions
+        type ListenEventsState = {
+          remote: SanityDocumentBase | undefined
+          local: SanityDocumentBase | undefined
+          stagedChanges: MutationGroup[]
+          hasSynced: boolean
+          pendingSyncEmit: boolean
+          prevLocal: SanityDocumentBase | undefined
+          prevRemote: SanityDocumentBase | undefined
+        }
+
+        let state: ListenEventsState = {
+          remote: undefined,
+          local: undefined,
+          stagedChanges: [],
+          hasSynced: false,
+          pendingSyncEmit: false,
+          prevLocal: undefined,
+          prevRemote: undefined,
+        }
+
+        let syncEmitScheduled = false
+
+        const emitSyncEvent = (isFromMutation = false) => {
+          if (state.pendingSyncEmit && state.hasSynced) {
+            // For sync events:
+            // - If emitted together with a mutation, after.local = remote (base state before mutations)
+            // - If emitted after mutations were already applied, after.local = local (with mutations)
+            const afterLocal = isFromMutation ? state.remote : state.local
+            const syncEvent: RemoteDocumentEvent = {
+              type: 'sync',
+              id,
+              before: {
+                local: state.prevLocal,
+                remote: state.prevRemote,
+              },
+              after: {
+                local: afterLocal,
+                remote: state.remote,
+              },
+              rebasedStage: state.stagedChanges,
+            }
+            state = {...state, pendingSyncEmit: false}
+            subscriber.next(syncEvent)
+          }
+        }
+
+        const scheduleSyncEmit = () => {
+          if (!syncEmitScheduled) {
+            syncEmitScheduled = true
+            Promise.resolve().then(() => {
+              syncEmitScheduled = false
+              emitSyncEvent()
+            })
+          }
+        }
+
+        // Listen to remote events from the backend
+        const remoteEvents$ = backend.listen(id).pipe(share())
+
+        const subscription = merge(
+          remoteEvents$.pipe(map(event => ({source: 'remote' as const, event}))),
+          localMutations$.pipe(map(group => ({source: 'local' as const, group}))),
+        ).subscribe({
+          next: action => {
+            if (action.source === 'remote') {
+              const event = action.event
+              if (event.type === 'sync') {
+                const newRemote = event.document
+                try {
+                  // When we get a sync, rebase local mutations on top of new remote state
+                  const [rebasedMutations] = rebase(
+                    id,
+                    state.remote,
+                    newRemote,
+                    state.stagedChanges,
+                  )
+                  // Apply rebased mutations to get local state
+                  const newLocal = applyAll(
+                    newRemote,
+                    filterDocumentTransactions(rebasedMutations, id),
+                  )
+                  state = {
+                    remote: newRemote,
+                    local: newLocal,
+                    stagedChanges: rebasedMutations,
+                    hasSynced: true,
+                    pendingSyncEmit: true,
+                    prevLocal: state.local,
+                    prevRemote: state.remote,
+                  }
+
+                  // If there are already staged mutations, emit immediately
+                  // Otherwise, schedule for next microtask to allow batching with synchronous mutations
+                  if (rebasedMutations.length > 0) {
+                    emitSyncEvent(false)
+                  } else {
+                    scheduleSyncEmit()
+                  }
+                } catch (err) {
+                  // Emit error on the observable when rebase fails
+                  // This can happen e.g. when trying to create a document that already exists
+                  subscriber.error(err)
+                  return
+                }
+              }
+            } else {
+              // Local mutation
+              const newStagedChanges = [...state.stagedChanges, action.group]
+              const newLocal = applyAll(
+                state.remote,
+                filterDocumentTransactions(newStagedChanges, id),
+              )
+
+              // Capture beforeLocal BEFORE we potentially emit sync event
+              // If there's a pending sync, before should be the remote state (base state before any mutations)
+              const wasPendingSync = state.pendingSyncEmit
+              const beforeLocal = wasPendingSync ? state.remote : state.local
+
+              // If there's a pending sync emit, update state and emit now
+              if (wasPendingSync) {
+                state = {
+                  ...state,
+                  stagedChanges: newStagedChanges,
+                  local: newLocal,
+                }
+                // Emit the sync event immediately with the mutation included
+                // Pass true to indicate this is from a mutation (so after.local = base state)
+                emitSyncEvent(true)
+              } else if (state.hasSynced) {
+                // Emit a sync event with updated rebasedStage
+                // after.local should be the result of applying mutations (newLocal),
+                // not the old local state
+                const syncEvent: RemoteDocumentEvent = {
+                  type: 'sync',
+                  id,
+                  before: {
+                    local: state.local,
+                    remote: state.remote,
+                  },
+                  after: {
+                    local: newLocal,
+                    remote: state.remote,
+                  },
+                  rebasedStage: newStagedChanges,
+                }
+                subscriber.next(syncEvent)
+              }
+
+              // Emit the optimistic event
+              const optimisticEvent: OptimisticDocumentEvent = {
+                type: 'optimistic',
+                id,
+                before: beforeLocal,
+                after: newLocal,
+                mutations: [],
+                stagedChanges: action.group.mutations,
+              }
+
+              state = {
+                ...state,
+                local: newLocal,
+                stagedChanges: newStagedChanges,
+                pendingSyncEmit: false,
+                prevLocal: beforeLocal,
+                prevRemote: state.remote,
+              }
+
+              subscriber.next(optimisticEvent)
+            }
+          },
+          error: err => subscriber.error(err),
+          complete: () => subscriber.complete(),
+        })
+
+        return () => subscription.unsubscribe()
+      })
     },
     submit: () => {
       onSubmitLocal.next()
@@ -313,7 +489,14 @@ export function createOptimisticStoreInternal(
         scan((state: LocalState, ev) => {
           const {base, inflight, local} = state
           if (ev.type === 'sync') {
-            return {...state, base: ev.snapshot}
+            // When a sync event arrives, the document might already include effects of
+            // inflight transactions (if they were applied before the sync event was received).
+            // Remove any inflight transactions that match the document's revision.
+            const docRev = ev.snapshot?._rev
+            const newInflight = docRev
+              ? inflight.filter(tx => tx.id !== docRev)
+              : inflight
+            return {...state, base: ev.snapshot, inflight: newInflight}
           }
           if (ev.type === 'localMutation') {
             return {

--- a/src/store/optimistic/optimisticStore.test.ts
+++ b/src/store/optimistic/optimisticStore.test.ts
@@ -1,6 +1,8 @@
 import {concat, delay, NEVER, of, take} from 'rxjs'
 import {describe, expect, test} from 'vitest'
 
+import {at, patch} from '../../mutations/creators'
+import {set} from '../../mutations/operations/creators'
 import {allValuesFrom, collectNotifications, sleep} from '../__test__/helpers'
 import {createOptimisticStore} from './createOptimisticStore'
 
@@ -301,6 +303,89 @@ describe('local mutations', () => {
       },
       {kind: 'ERROR', error: {message: 'Document already exist'}},
     ])
+
+    unsubscribe()
+  })
+
+  test('mutating after sync has been fully emitted (async gap)', async () => {
+    const doc = {_id: 'foo', _type: 'foo', title: 'original'}
+    const store = createOptimisticStore({
+      listen: id => of({type: 'sync', id, document: doc} as const),
+      submit: () => NEVER,
+    })
+
+    const {notifications, unsubscribe} = collectNotifications(
+      store.listenEvents('foo'),
+    )
+
+    // Wait for the sync event to be fully emitted via the scheduled microtask
+    await sleep(10)
+
+    // At this point, the sync event should have been emitted
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]).toMatchObject({
+      kind: 'NEXT',
+      value: {
+        type: 'sync',
+        id: 'foo',
+        after: {local: doc, remote: doc},
+      },
+    })
+
+    // Now mutate - this should hit the "else if (state.hasSynced)" branch
+    // because there's no pending sync emit
+    store.mutate([patch('foo', at('title', set('updated')))])
+
+    // Should have 3 notifications now: initial sync, new sync with mutation, and optimistic
+    expect(notifications).toHaveLength(3)
+
+    // The second notification should be a sync event with the mutation in rebasedStage
+    // and after.local should reflect the mutated state
+    expect(notifications[1]).toMatchObject({
+      kind: 'NEXT',
+      value: {
+        type: 'sync',
+        id: 'foo',
+        before: {
+          local: {_id: 'foo', _type: 'foo', title: 'original'},
+          remote: {_id: 'foo', _type: 'foo', title: 'original'},
+        },
+        after: {
+          local: {_id: 'foo', _type: 'foo', title: 'updated'},
+          remote: {_id: 'foo', _type: 'foo', title: 'original'},
+        },
+        rebasedStage: [
+          {
+            transaction: false,
+            mutations: [
+              {
+                type: 'patch',
+                id: 'foo',
+                patches: [{path: ['title'], op: {type: 'set', value: 'updated'}}],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    // The third notification should be the optimistic event
+    expect(notifications[2]).toMatchObject({
+      kind: 'NEXT',
+      value: {
+        type: 'optimistic',
+        id: 'foo',
+        before: {_id: 'foo', _type: 'foo', title: 'original'},
+        after: {_id: 'foo', _type: 'foo', title: 'updated'},
+        stagedChanges: [
+          {
+            type: 'patch',
+            id: 'foo',
+            patches: [{path: ['title'], op: {type: 'set', value: 'updated'}}],
+          },
+        ],
+      },
+    })
 
     unsubscribe()
   })


### PR DESCRIPTION
### Description

This PR implements the previously stubbed `listenEvents` method in `createOptimisticStore` and fixes several bugs that were causing the collaborative editing test to fail.

It builds on my previous PR's, so please only look at commit https://github.com/sanity-io/mutate/pull/91/changes/668b3a711c07078308bc0f7e3b1ce4a74d23385b

- **fix(store): populate mutations array in applyMutations** - The `muts` array was initialized but never populated, causing mutation events to have empty `mutations` arrays. This prevented listeners from applying changes correctly.

- **fix(store): clear acknowledged inflight transactions on sync** - When a sync event arrives with a document that already includes effects of inflight transactions (due to async timing with the dataloader), those transactions are now correctly removed from the inflight queue based on the document's `_rev`.

- **fix(store): use correct after.local in sync events** - The sync event emitted when mutations arrive after an async gap now correctly uses the mutated state for `after.local` rather than the pre-mutation state.


- **feat(store): implement listenEvents method** - Full implementation of the `listenEvents` observable that:
  - Tracks remote and local document state
  - Uses microtask batching (`Promise.resolve`) to group synchronous mutations with sync events
  - Emits `RemoteDocumentEvent` for sync events with `rebasedStage` containing pending mutations
  - Emits `OptimisticDocumentEvent` for local mutations showing before/after states
  - Properly handles errors during rebase (e.g., create collision)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
#### `listenEvents`

I implemented the `listenEvents` changes based on what the existing tests expected. The tests define specific semantics:

* Emit sync events with before/after states and rebasedStage
* Emit optimistic events for local mutations
* Use microtask batching for synchronous mutation grouping

However, I can't verify if these test expectations match the intended design for the refactored stable-store branch. The tests could be outdated.

#### Clear acknowledged inflight transactions on sync

This fix handles a race condition where:
 * Async document loading (via dataloader's asyncScheduler)
 * Create transaction completes before load finishes
 * Sync arrives with already-created document
 * Inflight queue still has the create transaction

My fix removes inflight transactions matching the sync _rev. But this might be masking a deeper architectural issue:
 * Should the mock backend use synchronous loading for tests?
 * Should sequentializeListenerEvents notify when it discards events?
 * Is the internal listen method's design compatible with the new event flow?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
- Updated `collaborative.test.ts` to use `toMatchObject` for assertions (allows for `_rev` field)
- Added new test case for mutations arriving after an async gap from sync events

All tests now pass.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
