### PR TITLE
chore: drop engines field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Common commands
 
-Package manager is **pnpm**; Node `>=20.19 <22 || >=22.12`.
+Package manager is **pnpm**.
 
 - `pnpm dev` — `pkg watch` (rebuild dist on change)
 - `pnpm build` — `pkg build --strict --check --clean` (uses `@sanity/pkg-utils` with `package.config.ts`; dts via rolldown)

--- a/package.json
+++ b/package.json
@@ -113,9 +113,6 @@
     }
   },
   "packageManager": "pnpm@10.28.2",
-  "engines": {
-    "node": ">=20.19 <22 || >=22.12"
-  },
   "publishConfig": {
     "exports": {
       ".": "./dist/index.js",


### PR DESCRIPTION
### Description
The runtime code uses no Node-specific APIs; the previous constraint (`>=20.19 <22 || >=22.12`) was a Vite/Vitest toolchain range copy-pasted from a template and would have wrongly barred Node 22.0–22.11. Runtime deps (`@sanity/client`, etc.) declare their own engines, but are not really relevant for browser engines anyway.

### What to review


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
