### PR TITLE
ci: fix npm provenance on release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,8 +52,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
       # Release Please has already incremented versions and published tags, so we just
-      # need to publish the new version to npm here
-      - run: pnpm publish
+      # need to publish the new version to npm here.
+      - run: pnpm publish --provenance --no-git-checks
         if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}
-        env:
-          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
pnpm@11 no longer reads `NPM_CONFIG_*` env vars, so using `--provenance` instead

