### PR TITLE
refactor(apply): type level tracking of adds and deletes in applyInCollection

### DIFF
--- a/docs/guide/applying-mutations.md
+++ b/docs/guide/applying-mutations.md
@@ -13,7 +13,7 @@ The apply engine exports pure functions for applying mutations to in-memory docu
 import {createIfNotExists, del} from '@sanity/mutate'
 import {applyInCollection} from '@sanity/mutate/_unstable_apply'
 
-const initial = [{_id: 'deleteme', _type: 'foo'}]
+const initial = [{_id: 'deleteme', _type: 'foo'}] as const
 
 const mutations = [
   createIfNotExists({_id: 'mydocument', _type: 'foo'}),
@@ -38,7 +38,7 @@ const initial = [
     value: 'ok',
     nested: {value: 'something'},
   },
-]
+] as const
 
 const updated = applyInCollection(initial, [
   createIfNotExists({_id: 'someDoc', _type: 'foo'}),
@@ -63,7 +63,7 @@ const initial = [
     nested: {value: 'something'},
     otherNested: {message: 'something else'},
   },
-]
+] as const
 
 const updated = applyInCollection(initial, [
   patch('someDoc', [at('otherNested.message', set('hello'))]),

--- a/src/apply/__test__/applyInCollection.test-d.ts
+++ b/src/apply/__test__/applyInCollection.test-d.ts
@@ -1,0 +1,125 @@
+import {assertType, describe, test} from 'vitest'
+
+import {
+  at,
+  create,
+  createIfNotExists,
+  createOrReplace,
+  del,
+  patch,
+} from '../../mutations/creators'
+import {set} from '../../mutations/operations/creators'
+import {applyInCollection} from '../applyInCollection'
+
+describe('applyInCollection — input variance', () => {
+  test('accepts a mutable Doc[] collection', () => {
+    const initial = [{_id: 'a', _type: 'foo'}]
+    applyInCollection(initial, [])
+  })
+
+  test('accepts a `readonly` collection (e.g. `as const`)', () => {
+    const initial = [{_id: 'a', _type: 'foo'}] as const
+    applyInCollection(initial, [])
+  })
+})
+
+describe('applyInCollection — added document shapes appear in the result', () => {
+  test('createIfNotExists contributes its document shape', () => {
+    const updated = applyInCollection(
+      [],
+      [createIfNotExists({_id: 'a', _type: 'foo'} as const)],
+    )
+    assertType<readonly {readonly _id: 'a'; readonly _type: 'foo'}[]>(updated)
+  })
+
+  test('create contributes its document shape', () => {
+    const updated = applyInCollection(
+      [],
+      [create({_id: 'a', _type: 'foo'} as const)],
+    )
+    assertType<readonly {readonly _id: 'a'; readonly _type: 'foo'}[]>(updated)
+  })
+
+  test('createOrReplace contributes its document shape', () => {
+    const updated = applyInCollection(
+      [],
+      [createOrReplace({_id: 'a', _type: 'foo'} as const)],
+    )
+    assertType<readonly {readonly _id: 'a'; readonly _type: 'foo'}[]>(updated)
+  })
+
+  test('input + added shapes union together', () => {
+    const initial = [{_id: 'existing', _type: 'foo'}] as const
+    const updated = applyInCollection(initial, [
+      createIfNotExists({_id: 'added', _type: 'foo'} as const),
+    ])
+    assertType<
+      readonly (
+        | {readonly _id: 'existing'; readonly _type: 'foo'}
+        | {readonly _id: 'added'; readonly _type: 'foo'}
+      )[]
+    >(updated)
+  })
+})
+
+describe('applyInCollection — del() subtracts matching shapes', () => {
+  test('a literal del removes the matching _id from the input union', () => {
+    const initial = [
+      {_id: 'keep', _type: 'foo'},
+      {_id: 'goaway', _type: 'foo'},
+    ] as const
+    const updated = applyInCollection(initial, [del('goaway')])
+    assertType<readonly {readonly _id: 'keep'; readonly _type: 'foo'}[]>(
+      updated,
+    )
+  })
+
+  test('a literal del removes a previously-added shape with the same _id', () => {
+    const updated = applyInCollection(
+      [],
+      [createIfNotExists({_id: 'tmp', _type: 'foo'} as const), del('tmp')],
+    )
+    // The added shape and the del cancel out; nothing remains in the union.
+    assertType<readonly never[]>(updated)
+  })
+
+  test('a non-literal del (string) does NOT subtract', () => {
+    const initial = [
+      {_id: 'a', _type: 'foo'},
+      {_id: 'b', _type: 'foo'},
+    ] as const
+    const id: string = 'a'
+    const updated = applyInCollection(initial, [del(id)])
+    // Without a literal id, the Exclude is a no-op — the result keeps both.
+    assertType<
+      readonly (
+        | {readonly _id: 'a'; readonly _type: 'foo'}
+        | {readonly _id: 'b'; readonly _type: 'foo'}
+      )[]
+    >(updated)
+  })
+})
+
+describe('applyInCollection — patch() is shape-preserving', () => {
+  test('patch does not add or subtract shapes from the result', () => {
+    const initial = [{_id: 'a', _type: 'foo', name: 'x'}] as const
+    const updated = applyInCollection(initial, [
+      patch('a', [at('name', set('y'))]),
+    ])
+    assertType<
+      readonly {
+        readonly _id: 'a'
+        readonly _type: 'foo'
+        readonly name: 'x'
+      }[]
+    >(updated)
+  })
+})
+
+describe('applyInCollection — empty mutations preserves input shape', () => {
+  test('an empty mutation list returns the input shape', () => {
+    const initial = [{_id: 'a', _type: 'foo'}] as const
+    const updated = applyInCollection(initial, [])
+    assertType<readonly {readonly _id: 'a'; readonly _type: 'foo'}[]>(updated)
+  })
+})

--- a/src/apply/applyInCollection.ts
+++ b/src/apply/applyInCollection.ts
@@ -11,12 +11,41 @@ import {arrify} from '../utils/arrify'
 import {applyPatchMutation} from './applyPatchMutation'
 import {splice} from './utils/array'
 
-export function applyInCollection<Doc extends SanityDocumentBase>(
-  collection: Doc[],
-  mutations: Mutation | Mutation[],
-) {
-  const a = arrify(mutations) as Mutation[]
-  return a.reduce((prev, mutation) => {
+/**
+ * Extracts the document shape an "add"-flavored mutation contributes.
+ * `delete` and `patch` don't introduce new shapes.
+ */
+type AddedDocument<M> =
+  M extends CreateMutation<infer D>
+    ? D
+    : M extends CreateIfNotExistsMutation<infer D>
+      ? D
+      : M extends CreateOrReplaceMutation<infer D>
+        ? D
+        : never
+
+/**
+ * Extracts the literal `_id` of any delete mutation in the union.
+ * `DeleteMutation<string>` (non-literal id) extracts to `string`, which
+ * makes Exclude<…> a no-op — so non-literal deletes leave the result
+ * type alone, which is the right behaviour.
+ */
+type DeletedId<M> = M extends DeleteMutation<infer Id> ? Id : never
+
+type MutationOf<Muts> = Muts extends readonly Mutation[] ? Muts[number] : Muts
+
+export function applyInCollection<
+  const Doc extends SanityDocumentBase,
+  const Muts extends Mutation | readonly Mutation[],
+>(
+  collection: readonly Doc[],
+  mutations: Muts,
+): readonly Exclude<
+  Doc | AddedDocument<MutationOf<Muts>>,
+  {_id: DeletedId<MutationOf<Muts>>}
+>[] {
+  const a = arrify(mutations as Mutation | Mutation[]) as Mutation[]
+  return a.reduce((prev: readonly SanityDocumentBase[], mutation) => {
     if (mutation.type === 'create') {
       return createIn(prev, mutation)
     }
@@ -34,11 +63,14 @@ export function applyInCollection<Doc extends SanityDocumentBase>(
     }
     // @ts-expect-error all cases should be covered
     throw new Error(`Invalid mutation type: ${mutation.type}`)
-  }, collection)
+  }, collection) as readonly Exclude<
+    Doc | AddedDocument<MutationOf<Muts>>,
+    {_id: DeletedId<MutationOf<Muts>>}
+  >[]
 }
 
 function createIn<Doc extends SanityDocumentBase>(
-  collection: Doc[],
+  collection: readonly Doc[],
   mutation: CreateMutation<Doc>,
 ) {
   const currentIdx = collection.findIndex(
@@ -51,7 +83,7 @@ function createIn<Doc extends SanityDocumentBase>(
 }
 
 function createIfNotExistsIn<Doc extends SanityDocumentBase>(
-  collection: Doc[],
+  collection: readonly Doc[],
   mutation: CreateIfNotExistsMutation<Doc>,
 ) {
   const currentIdx = collection.findIndex(
@@ -61,7 +93,7 @@ function createIfNotExistsIn<Doc extends SanityDocumentBase>(
 }
 
 function createOrReplaceIn<Doc extends SanityDocumentBase>(
-  collection: Doc[],
+  collection: readonly Doc[],
   mutation: CreateOrReplaceMutation<Doc>,
 ) {
   const currentIdx = collection.findIndex(
@@ -73,7 +105,7 @@ function createOrReplaceIn<Doc extends SanityDocumentBase>(
 }
 
 function deleteIn<Doc extends SanityDocumentBase>(
-  collection: Doc[],
+  collection: readonly Doc[],
   mutation: DeleteMutation,
 ) {
   const currentIdx = collection.findIndex(doc => doc._id === mutation.id)
@@ -81,9 +113,9 @@ function deleteIn<Doc extends SanityDocumentBase>(
 }
 
 function patchIn<Doc extends SanityDocumentBase>(
-  collection: Doc[],
+  collection: readonly Doc[],
   mutation: PatchMutation,
-): Doc[] {
+): readonly Doc[] {
   const currentIdx = collection.findIndex(doc => doc._id === mutation.id)
   if (currentIdx === -1) {
     throw new Error('Cannot apply patch on nonexistent document')

--- a/src/apply/utils/array.ts
+++ b/src/apply/utils/array.ts
@@ -31,18 +31,22 @@ export function normalizeIndex(length: number, index: number) {
 }
 
 // non-mutating splice
-export function splice<T>(arr: T[], start: number, deleteCount: number): T[]
 export function splice<T>(
-  arr: T[],
+  arr: readonly T[],
   start: number,
   deleteCount: number,
-  items: T[],
 ): T[]
 export function splice<T>(
-  arr: T[],
+  arr: readonly T[],
   start: number,
   deleteCount: number,
-  items?: T[],
+  items: readonly T[],
+): T[]
+export function splice<T>(
+  arr: readonly T[],
+  start: number,
+  deleteCount: number,
+  items?: readonly T[],
 ): T[] {
   const copy = arr.slice()
   copy.splice(start, deleteCount, ...(items || []))

--- a/src/mutations/creators.ts
+++ b/src/mutations/creators.ts
@@ -18,7 +18,7 @@ import {
   type SanityDocumentBase,
 } from './types'
 
-export function create<Doc extends Optional<SanityDocumentBase, '_id'>>(
+export function create<const Doc extends Optional<SanityDocumentBase, '_id'>>(
   document: Doc,
 ): CreateMutation<Doc> {
   return {type: 'create', document}
@@ -57,19 +57,19 @@ export function at<O extends Operation>(
   }
 }
 
-export function createIfNotExists<Doc extends SanityDocumentBase>(
+export function createIfNotExists<const Doc extends SanityDocumentBase>(
   document: Doc,
 ): CreateIfNotExistsMutation<Doc> {
   return {type: 'createIfNotExists', document}
 }
 
-export function createOrReplace<Doc extends SanityDocumentBase>(
+export function createOrReplace<const Doc extends SanityDocumentBase>(
   document: Doc,
 ): CreateOrReplaceMutation<Doc> {
   return {type: 'createOrReplace', document}
 }
 
-export function delete_(id: string): DeleteMutation {
+export function delete_<const Id extends string>(id: Id): DeleteMutation<Id> {
   return {type: 'delete', id}
 }
 

--- a/src/mutations/types.ts
+++ b/src/mutations/types.ts
@@ -35,9 +35,9 @@ export type CreateOrReplaceMutation<Doc extends SanityDocumentBase> = {
   document: Doc
 }
 
-export type DeleteMutation = {
+export type DeleteMutation<Id extends string = string> = {
   type: 'delete'
-  id: string
+  id: Id
 }
 
 export type PatchMutation<Patches extends NodePatchList = NodePatchList> = {


### PR DESCRIPTION
Improves `applyInCollection`'s result type to reflect what the mutation set actually does:
- `create` / `createIfNotExists` / `createOrReplace` are unioned into the result
- `delete` mutations with a literal `id` are subtracted from the result
- `patch` is shape-preserving.
- Also gains `<const Doc>` on `create` / `createIfNotExists` / `createOrReplace` so inline document literals auto-narrows without `as const`, and accepts `readonly` collections.

- Updated docs and examples
- Tests included in applyInCollection.test-d.ts

Docs examples should now work better:
Before: 
<img width="771" height="385" alt="image" src="https://github.com/user-attachments/assets/064a4ff6-a44b-480b-8a72-0683d0fa1f82" />
After:
<img width="830" height="530" alt="image" src="https://github.com/user-attachments/assets/ff2c5fa0-7df6-4f28-819e-7526e511b65f" />