### PR TITLE
fix: add explicit return types to autoKeys to fix broken .d.ts output

### DIFF
--- a/src/mutations/autoKeys.ts
+++ b/src/mutations/autoKeys.ts
@@ -1,11 +1,17 @@
 import {type Index, type KeyedPathElement} from '../path'
+import {type Arrify} from '../utils/arrify'
 import {isObject} from '../utils/isObject'
 import {
   insert as _insert,
   replace as _replace,
   upsert as _upsert,
 } from './operations/creators'
-import {type RelativePosition} from './operations/types'
+import {
+  type InsertOp,
+  type RelativePosition,
+  type ReplaceOp,
+  type UpsertOp,
+} from './operations/types'
 
 export function autoKeys<Item>(generateKey: (item: Item) => string) {
   const ensureKeys = createEnsureKeys(generateKey)
@@ -17,7 +23,8 @@ export function autoKeys<Item>(generateKey: (item: Item) => string) {
     position: Pos,
     referenceItem: Ref,
     items: Item[],
-  ) => _insert(ensureKeys(items), position, referenceItem)
+  ): InsertOp<(Item & {_key: string})[], Pos, Ref> =>
+    _insert(ensureKeys(items), position, referenceItem)
 
   const upsert = <
     Pos extends RelativePosition,
@@ -26,7 +33,8 @@ export function autoKeys<Item>(generateKey: (item: Item) => string) {
     items: Item[],
     position: Pos,
     referenceItem: ReferenceItem,
-  ) => _upsert(ensureKeys(items), position, referenceItem)
+  ): UpsertOp<Arrify<Item & {_key: string}>, Pos, ReferenceItem> =>
+    _upsert(ensureKeys(items), position, referenceItem)
 
   const replace = <
     Pos extends RelativePosition,
@@ -35,21 +43,29 @@ export function autoKeys<Item>(generateKey: (item: Item) => string) {
     items: Item[],
     position: Pos,
     referenceItem: ReferenceItem,
-  ) => _replace(ensureKeys(items), referenceItem)
+  ): ReplaceOp<(Item & {_key: string})[], ReferenceItem> =>
+    _replace(ensureKeys(items), referenceItem)
 
   const insertBefore = <Ref extends Index | KeyedPathElement>(
     ref: Ref,
     items: Item[],
-  ) => insert('before', ref, items)
+  ): InsertOp<(Item & {_key: string})[], 'before', Ref> =>
+    insert('before', ref, items)
 
-  const prepend = (items: Item[]) => insertBefore(0, items)
+  const prepend = (
+    items: Item[],
+  ): InsertOp<(Item & {_key: string})[], 'before', 0> => insertBefore(0, items)
 
   const insertAfter = <Ref extends Index | KeyedPathElement>(
     ref: Ref,
     items: Item[],
-  ) => insert('after', ref, items)
+  ): InsertOp<(Item & {_key: string})[], 'after', Ref> =>
+    insert('after', ref, items)
 
-  const append = (items: Item[]) => insert('after', -1, items)
+  const append = (
+    items: Item[],
+  ): InsertOp<(Item & {_key: string})[], 'after', -1> =>
+    insert('after', -1, items)
 
   return {insert, upsert, replace, insertBefore, prepend, insertAfter, append}
 }


### PR DESCRIPTION
### Description

The `autoKeys` function in `src/mutations/autoKeys.ts` produces broken `.d.ts` output because rolldown can't resolve inferred return types that cross module boundaries. The published `dist/index.d.ts` emits `undefined<...>` instead of `InsertOp<...>`, `UpsertOp<...>`, `ReplaceOp<...>`.

This was caught by the SDK's Renovate PR ([sanity-io/sdk#900](https://github.com/sanity-io/sdk/pull/900)), which failed to build after bumping to `@sanity/mutate@^0.17.1`. The [build failure](https://github.com/sanity-io/sdk/actions/runs/26169674659/job/76983513898?pr=900#step:4:170) shows `@sanity/sdk-react` choking on the malformed declarations.

The fix adds explicit return type annotations to every method inside `autoKeys`, matching the pattern already used for the sanity encoder fix in PR #64. The new imports (`InsertOp`, `ReplaceOp`, `UpsertOp` from `./operations/types` and `Arrify` from `../utils/arrify`) give rolldown concrete type references to emit instead of trying (and failing) to inline inferred types.

### What to review

- `src/mutations/autoKeys.ts` is the only file changed.
- Each inner function (`insert`, `upsert`, `replace`, `insertBefore`, `prepend`, `insertAfter`, `append`) now has an explicit return type annotation.
- Verify the annotated types match the actual return types from the delegated `_insert`/`_upsert`/`_replace` calls.
- `pnpm pkg:build` should produce a `dist/index.d.ts` with no `undefined<` tokens.

### Testing

- `pnpm typecheck` passes.
- `pnpm pkg:build` succeeds and `dist/index.d.ts` emits correct `InsertOp<...>`, `UpsertOp<...>`, `ReplaceOp<...>` types for `autoKeys`.
- Searched `dist/index.d.ts` for `undefined<` and confirmed zero matches.
- No new tests added; this is a type-only fix with no runtime behavior change. The existing test suite covers `autoKeys` behavior.
